### PR TITLE
Fix display of compound modifiers

### DIFF
--- a/blackmamba/uikit/keyboard.py
+++ b/blackmamba/uikit/keyboard.py
@@ -277,7 +277,7 @@ def _modifier_selector_name(modifier):
     flags = [
         name
         for mod, name in _names.items()
-        if mod.value & modifier == mod.value
+        if mod.value & modifier
     ]
 
     if flags:


### PR DESCRIPTION
Found this when investigating what each key shortcut does. Without it, compound modifiers are displayed as empty string, with this they show up correctly.